### PR TITLE
Update the container build and make it eaiser to work with ankflag

### DIFF
--- a/configs/210912ph.config
+++ b/configs/210912ph.config
@@ -10,11 +10,7 @@ params.casapath = "/fred/oz313/src/casa5.8/casa-release-5.8.0-109.el7/bin"
 
 // Containers
 params.celebi_container = "/fred/oz313/celebi_container_02mar24.sif" //celebi_Nov13.sif path to container where to run CELEBI
-params.cracrofunew_container = "/fred/oz313/cracofunew-2024-08-12.sif"
-
-// Containers
-params.celebi_container = "/fred/oz313/celebi_container_02mar24.sif" //celebi_Nov13.sif path to container where to run CELEBI
-params.cracrofunew_container = "/fred/oz313/cracofunew-2024-08-12.sif"
+params.cracrofunew_container = "/fred/oz313/cracofunew-2024-08-16.sif"
 
 // Flux calibrator
 includeConfig "0407.config"

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -11,7 +11,10 @@ ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
 # copy project requirements
-COPY ./cracofunew.yml .
+COPY ./containers/cracofunew.yml .
 
 # Create environment and activate it
 RUN mamba env update --name base --file cracofunew.yml
+
+COPY ./flagging/ /tmp/flagging/
+RUN cd /tmp/flagging && make && cp ankflag /usr/bin/. && rm -rf /temp/flagging

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -4,7 +4,7 @@ FROM condaforge/mambaforge:latest as cracofunew
 LABEL description = "Container for running CELEBI python scripts"
 
 # Install curl
-RUN apt-get -y update && apt install -y bc
+RUN apt-get -y update && apt install -y bc make gcc libgsl23 libgsl-dev
 
 # set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/containers/build.sh
+++ b/containers/build.sh
@@ -1,0 +1,3 @@
+#! /usr/bin/env bash
+cd ${BASH_SOURCE%/*}/..
+docker build -t cracofunew:latest -f containers/Dockerfile .

--- a/flagging/doflag.py
+++ b/flagging/doflag.py
@@ -8,10 +8,16 @@ import subprocess
 #-----------------------------------------------------------------------------------------------
 
 def run(cmd):
-    ret = subprocess.run(cmd, shell=True).returncode
-    if ret != 0:
+    print(f'doflag - {cmd}')
+    result = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if result.returncode != 0:
         print(f"ERR:FAILED COMMAND:{cmd}")
-        sys.exit(ret)
+        print(" -- STDOUT -- ")
+        print(result.stdout.decode('utf-8'))
+        print(" -- STDERR -- ")
+        print(result.stderr.decode('utf-8'))
+        print(" ---- ")
+        sys.exit(result.returncode)
 
 
 if(len(sys.argv)<7):
@@ -31,19 +37,14 @@ badantfile	= sys.argv[6]
 
 print("doflag running with -- "+infits+" "+outfits+" "+badchanfile+" "+flagmode+" "+logfile+" "+badantfile+"\n")
 
-print("copying goutfile -- cp "+ankdir+"glogout.dat .")
+print("copying goutfile")
 run("cp "+ankdir+"glogout.dat .")
 
 if(flagmode=='proper'):
-    print("doflag - python3 "+ankdir+"runank.py "+infits+" temp_1.fits 1 "+badchanfile+" 1 >> "+logfile)
     run("python3 "+ankdir+"runank.py "+infits+" temp_1.fits 1 "+badchanfile+" 1 >> "+logfile)
-    print("doflag - python3 "+ankdir+"runank.py temp_1.fits temp_2.fits 2 none 0 >> "+logfile)
     run("python3 "+ankdir+"runank.py temp_1.fits temp_2.fits 2 none 0 >> "+logfile)
-    print("doflag - python3 "+ankdir+"runank.py temp_2.fits temp_3.fits 3 none 0 >> "+logfile)
     run("python3 "+ankdir+"runank.py temp_2.fits temp_3.fits 3 none 0 >> "+logfile)
-    print("doflag -python3 "+ankdir+"runank.py temp_3.fits "+outfits+" 4 none 0 >> "+logfile )
     run("python3 "+ankdir+"runank.py temp_3.fits "+outfits+" 4 none 0 >> "+logfile)
-    print("doflag - python3 "+ankdir+"print_badant.py "+outfits+" "+badantfile+" >> "+logfile)
     run("python3 "+ankdir+"print_badant.py "+outfits+" "+badantfile+" >> "+logfile)
     run("rm -rf temp_*.fits")
 else:

--- a/flagging/runank.py
+++ b/flagging/runank.py
@@ -1,8 +1,22 @@
 import os,sys
 import numpy as np
 import time as tm
+import subprocess
 from convertfits import *
 from inputs import *
+
+
+def run(cmd):
+    result = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if result.returncode != 0:
+        print(f"ERR:FAILED COMMAND:{cmd}")
+        print(" -- STDOUT -- ")
+        print(result.stdout.decode('utf-8'))
+        print(" -- STDERR -- ")
+        print(result.stderr.decode('utf-8'))
+        print(" ---- ")
+        sys.exit(result.returncode)
+    return result.returncode
 
 #	----------------------------------------------
 
@@ -119,7 +133,7 @@ start1	=	tm.time()
 
 if (DOFLAG):
     print("runank - running core flagging")
-    status	=	os.system('module load gcc/12.2.0 && module load gsl/2.7 && '+ANKDIR+'/ankflag')	
+    status	=	run('ankflag')	
     print("\nFlagging done in 		%d seconds\n"%(tm.time()-start1))
 	
 #	------------------------------		Convert back binary files to FITS	
@@ -184,7 +198,7 @@ if (READBACK):
 
 if (CLEARSCRATCH):
     print('\nClearing scratch directory....\n')
-    os.system('rm -rf '+scratchdir)
+    run('rm -rf '+scratchdir)
 
 
 

--- a/pipelines/flagging.nf
+++ b/pipelines/flagging.nf
@@ -58,7 +58,7 @@ process flag_proper {
         badchanfile="${flagging_dir}badchannels_askap_\${askap_band}_${src}.txt"
         echo "Bad channel file \${badchanfile}"
 
-        /fred/oz313/anaconda/anaconda3/bin/conda run -n cracofunew python3 ${flagging_dir}doflag.py infitsfile.fits outfitsfile.fits \${badchanfile} proper logfile.txt bad_ant_file.txt
+        python3 ${flagging_dir}doflag.py infitsfile.fits outfitsfile.fits \${badchanfile} proper logfile.txt bad_ant_file.txt
 
         cp outfitsfile.fits ${outfitsfilepub}
         """
@@ -119,7 +119,7 @@ process flag_initial {
         badchanfile = ${flagging_dir}badchannels_askap_${askapband}_${src}.txt
         echo "Bad channel file ${badchanfile}"
 
-        /fred/oz313/anaconda/anaconda3/bin/conda run -n cracofunew python3 ${flagging_dir}doflag.py ${infitsfile} ${outfitsfile}.fits ${badchanfile} initital logfile.txt none
+        python3 ${flagging_dir}doflag.py ${infitsfile} ${outfitsfile}.fits ${badchanfile} initital logfile.txt none
         """
     
     stub:


### PR DESCRIPTION
This is an increment on #483.

- Added a convenience function for building the docker container `container/build.sh`
- Caused the `ankflag` binary to be built and shipped with the container (in `/usr/bin/`)
- Refactored the python scripts in `flagging/` so that they don't assume a location for the `ankflag` binary
- Confirmed that the new container and modified codes work with the workflow
